### PR TITLE
Fix showing ids or class

### DIFF
--- a/gla11y
+++ b/gla11y
@@ -33,10 +33,10 @@ def errstr(elm):
     global pflag
 
     if pflag:
-        path = elm.attrib['class']
+        path = elm.attrib['id']
         elm = elm.getparent()
         while elm is not None:
-            klass = elm.attrib.get('class')
+            klass = elm.attrib.get('id')
             if klass is not None:
                 path = klass + '/' + path
             elm = elm.getparent()
@@ -157,7 +157,7 @@ def check_a11y_relation(filename, root):
                     ": lines %s" % (oid, lines))
                 continue
 
-            warn(filename, obj, "element '%s' has no relation" % oid)
+            warn(filename, obj, "element '%s' '%s' has no relation" % (obj.attrib['class'], oid))
             continue
 
         klass = obj.attrib['class']


### PR DESCRIPTION
We want the suppression rules etc. to contain the ids rather than the widgets types (which are ambiguous).

In the warnings, having the widgets types is really useful.